### PR TITLE
Adding support to flash seeed studios xiao esp32s3 boards

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,6 +882,28 @@
                             },
                         ],
                     },
+                    {
+                        name: "Seeed Studio XIAO ESP32S3",
+                        id: ROM.PRODUCT_XIAO_ESP32S3,
+                        platform: ROM.PLATFORM_ESP32,
+                        models: [
+                            {
+                                id: ROM.MODEL_DD,
+                                name: "868 MHz / 915 MHz / 923 MHz",
+                            },
+                        ],
+                        firmware_filename: "rnode_firmware_xiao_esp32s3.zip",
+                        flash_config: {
+                            flash_size: "8MB",
+                            flash_files: {
+                                "0xe000": "rnode_firmware_xiao_esp32s3.boot_app0",
+                                "0x0": "rnode_firmware_xiao_esp32s3.bootloader",
+                                "0x10000": "rnode_firmware_xiao_esp32s3.bin",
+                                "0x210000": "console_image.bin",
+                                "0x8000": "rnode_firmware_xiao_esp32s3.partitions",
+                            },
+                        },
+                    },
                 ],
 
                 // Liam's default config for New Zealand / LongFast on Slot 10

--- a/js/rnode.js
+++ b/js/rnode.js
@@ -117,6 +117,7 @@ class RNode {
     BOARD_LORA32_V2_0 = 0x36;
     BOARD_LORA32_V2_1 = 0x37;
     BOARD_RAK4631 = 0x51;
+    BOARD_XIAO_ESP32S3 = 0x3E
 
     HASH_TYPE_TARGET_FIRMWARE = 0x01;
     HASH_TYPE_FIRMWARE = 0x02;
@@ -844,6 +845,9 @@ class ROM {
     static MODEL_FF       = 0xFF
     static MODEL_FE       = 0xFE
 
+    static PRODUCT_XIAO_ESP32S3 = 0xEB
+    static MODEL_DD             = 0xDD
+
     static ADDR_PRODUCT   = 0x00
     static ADDR_MODEL     = 0x01
     static ADDR_HW_REV    = 0x02
@@ -870,6 +874,7 @@ class ROM {
     static BOARD_LORA32_V2_0   = 0x36
     static BOARD_LORA32_V2_1   = 0x37
     static BOARD_RAK4631       = 0x51
+    static BOARD_XIAO_ESP32S3  = 0x3E
 
     static MANUAL_FLASH_MODELS = [ROM.MODEL_A1, ROM.MODEL_A6]
 


### PR DESCRIPTION
* Closes #10 
* Currently only supported by the CE firmware

Already used 8mb flash size, while CE firmware still has an open PR for it: https://github.com/liberatedsystems/RNode_Firmware_CE/pull/72